### PR TITLE
Remove matches table

### DIFF
--- a/vagrant/tournament/tournament.py
+++ b/vagrant/tournament/tournament.py
@@ -49,13 +49,11 @@ def fetch_query(*query):
 
 def deleteMatches():
     """Remove all the match records from the database."""
-    commit_query("DELETE from Matches")
     commit_query("UPDATE players set wins = 0, losses = 0")
 
 
 def deletePlayers():
     """Remove all the player records from the database."""
-    deleteMatches()
     commit_query("DELETE from Players")
 
 
@@ -112,8 +110,6 @@ def reportMatch(winner, loser):
         "UPDATE players SET wins = wins + 1 WHERE id = %s", (winner,))
     commit_query(
         "UPDATE players SET losses = losses + 1 WHERE id = %s", (loser,))
-    commit_query(
-        "INSERT INTO matches (winner, loser) values (%s, %s)", (winner, loser,))
  
  
 def swissPairings():

--- a/vagrant/tournament/tournament.sql
+++ b/vagrant/tournament/tournament.sql
@@ -6,20 +6,11 @@
 -- You can write comments in this file by starting them with two dashes, like
 -- these lines here.
 
-DROP DATABASE IF EXISTS tournament;
-
 CREATE DATABASE tournament;
 \c tournament
-DROP TABLE IF EXISTS players CASCADE;
-DROP TABLE IF EXISTS matches;
 CREATE TABLE players (
     id serial UNIQUE primary key,
     name text,
     wins integer DEFAULT 0,
     losses integer DEFAULT 0
-    );
-CREATE TABLE matches (
-    winner integer REFERENCES players,
-    loser integer REFERENCES players,
-    primary key (winner, loser)
     );


### PR DESCRIPTION
Removes all references to the matches table.

After thinking about it I didn't see myself ever getting data from the matches table. After removing all references to the table, I tried running the unit tests and they all passed, so out the table comes.

That's not to say it wouldn't be useful at all. If you were to create a function to run a whole tournament given the players, you would probably need a matches table to ensure players don't play against eachother more than once (assuming that's what you want).

But for this particular application, I don't see a use in a matches table.